### PR TITLE
Update URLs to not point to hubot-scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
 
   "repository": {
     "type": "git",
-    "url": "git://github.com/hubot-scripts/hubot-rate-limit.git"
+    "url": "git://github.com/michaelansel/hubot-rate-limit.git"
   },
 
   "bugs": {
-    "url": "https://github.com/hubot-scripts/hubot-rate-limit/issues"
+    "url": "https://github.com/michaelansel/hubot-rate-limit/issues"
   },
 
   "dependencies": {


### PR DESCRIPTION
hubot-scripts is dead. Links should point to michaelansel/hubot
