### PR TITLE
Nicer formatting of `debug rate limits` output

### DIFF
--- a/src/rate-limit.coffee
+++ b/src/rate-limit.coffee
@@ -27,8 +27,11 @@ module.exports = (robot) ->
     notifyPeriodMs = 10*1000 # default: 10s
 
   robot.respond /debug rate limits/, {rateLimits:{minPeriodMs:0}}, (response) ->
-    response.reply('lastExecutedTime: ' + JSON.stringify(lastExecutedTime))
-    response.reply('lastNotifiedTime: ' + JSON.stringify(lastNotifiedTime))
+    response.reply("""
+      ```
+      lastExecutedTime: #{JSON.stringify(lastExecutedTime, null, 4)}
+      lastNotifiedTime: #{JSON.stringify(lastNotifiedTime, null, 4)}
+      ```""")
 
   robot.listenerMiddleware (context, next, done) ->
     # Retrieve the listener id. If one hasn't been registered, fallback


### PR DESCRIPTION
Indent all the JSONs (http://i.imgur.com/OMgdvqY.jpg) and enclose in triple backquote ('```')
### Old

<img width="667" alt="screen shot 2015-10-23 at 6 00 03 am" src="https://cloud.githubusercontent.com/assets/305268/10693148/5d94477a-794b-11e5-99d6-4433678f4a55.png">
### New

<img width="669" alt="screen shot 2015-10-23 at 6 00 40 am" src="https://cloud.githubusercontent.com/assets/305268/10693160/705ada0e-794b-11e5-9ce5-b6a21c138d64.png">
