### PR TITLE
Added new (optional) environment variable to supress limit exceeded chat messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Then add **hubot-rate-limit** to your `external-scripts.json`:
 
 `HUBOT_RATE_LIMIT_NOTIFY_PERIOD` - default interval (seconds) between posting rate limiting messages in chat
 `HUBOT_RATE_LIMIT_CMD_PERIOD` - default interval (seconds) between each invocation of a specific listener
+`HUBOT_RATE_LIMIT_NOTIFY_MSG` - (Optional) Setting this environment variable to any value will supress rate limit exceeded feedback messages in chat.
 
 `HUBOT_RATE_LIMIT_CMD_PERIOD` can be overridden using listener options:
 ```coffeescript

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then add **hubot-rate-limit** to your `external-scripts.json`:
 
 `HUBOT_RATE_LIMIT_NOTIFY_PERIOD` - default interval (seconds) between posting rate limiting messages in chat
 `HUBOT_RATE_LIMIT_CMD_PERIOD` - default interval (seconds) between each invocation of a specific listener
-`HUBOT_RATE_LIMIT_NOTIFY_MSG` - (Optional) Setting this environment variable to any value will supress rate limit exceeded feedback messages in chat.
+`HUBOT_RATE_LIMIT_SILENT` - (Optional) Setting this environment variable to any truthy value will supress rate limit exceeded feedback messages in chat.
 
 `HUBOT_RATE_LIMIT_CMD_PERIOD` can be overridden using listener options:
 ```coffeescript

--- a/src/rate-limit.coffee
+++ b/src/rate-limit.coffee
@@ -61,16 +61,18 @@ module.exports = (robot) ->
          lastExecutedTime[listenerAndRoom] > Date.now() - minPeriodMs
         # Command is being executed too quickly!
         robot.logger.debug "Rate limiting " + listenerID + " in " + roomOrUser + "; #{minPeriodMs} > #{Date.now() - lastExecutedTime[listenerAndRoom]}"
-        # Notify at least once per rate limiting event
-        myNotifyPeriodMs = minPeriodMs if notifyPeriodMs > minPeriodMs
-        # If no notification sent recently
-        if (lastNotifiedTime.hasOwnProperty(listenerAndRoom) and
-            lastNotifiedTime[listenerAndRoom] < Date.now() - myNotifyPeriodMs) or
-           not lastNotifiedTime.hasOwnProperty(listenerAndRoom)
-          context.response.reply "Rate limit hit! Please wait #{minPeriodMs/1000} seconds before trying again."
-          lastNotifiedTime[listenerAndRoom] = Date.now()
-        # Bypass executing the listener callback
-        done()
+
+        if process.env.HUBOT_RATE_LIMIT_NOTIFY_MSG?
+          # Notify at least once per rate limiting event
+          myNotifyPeriodMs = minPeriodMs if notifyPeriodMs > minPeriodMs
+          # If no notification sent recently
+          if (lastNotifiedTime.hasOwnProperty(listenerAndRoom) and
+              lastNotifiedTime[listenerAndRoom] < Date.now() - myNotifyPeriodMs) or
+             not lastNotifiedTime.hasOwnProperty(listenerAndRoom)
+            context.response.reply "Rate limit hit! Please wait #{minPeriodMs/1000} seconds before trying again."
+            lastNotifiedTime[listenerAndRoom] = Date.now()
+          # Bypass executing the listener callback
+          done()
       else
         next () ->
           lastExecutedTime[listenerAndRoom] = Date.now()

--- a/src/rate-limit.coffee
+++ b/src/rate-limit.coffee
@@ -62,17 +62,17 @@ module.exports = (robot) ->
         # Command is being executed too quickly!
         robot.logger.debug "Rate limiting " + listenerID + " in " + roomOrUser + "; #{minPeriodMs} > #{Date.now() - lastExecutedTime[listenerAndRoom]}"
 
-        if process.env.HUBOT_RATE_LIMIT_NOTIFY_MSG?
-          # Notify at least once per rate limiting event
-          myNotifyPeriodMs = minPeriodMs if notifyPeriodMs > minPeriodMs
-          # If no notification sent recently
-          if (lastNotifiedTime.hasOwnProperty(listenerAndRoom) and
-              lastNotifiedTime[listenerAndRoom] < Date.now() - myNotifyPeriodMs) or
-             not lastNotifiedTime.hasOwnProperty(listenerAndRoom)
+        # Notify at least once per rate limiting event
+        myNotifyPeriodMs = minPeriodMs if notifyPeriodMs > minPeriodMs
+        # If no notification sent recently
+        if (lastNotifiedTime.hasOwnProperty(listenerAndRoom) and
+            lastNotifiedTime[listenerAndRoom] < Date.now() - myNotifyPeriodMs) or
+           not lastNotifiedTime.hasOwnProperty(listenerAndRoom)
+          if not process.env.HUBOT_RATE_LIMIT_SILENT?
             context.response.reply "Rate limit hit! Please wait #{minPeriodMs/1000} seconds before trying again."
-            lastNotifiedTime[listenerAndRoom] = Date.now()
-          # Bypass executing the listener callback
-          done()
+          lastNotifiedTime[listenerAndRoom] = Date.now()
+        # Bypass executing the listener callback
+        done()
       else
         next () ->
           lastExecutedTime[listenerAndRoom] = Date.now()


### PR DESCRIPTION
I had a use case where I needed to rate limit responses to various keyword triggers, but did not want the rate limit exceeded messages cluttering up the chat.  This simple merge adds a new optional environment variable 'HUBOT_RATE_LIMIT_NOTIFY_MSG' that if set to any value will suppress these warnings and leave your channel nice and clean.
